### PR TITLE
add validator name to all alerts

### DIFF
--- a/targets/gaiacli_status.go
+++ b/targets/gaiacli_status.go
@@ -3,6 +3,7 @@ package targets
 import (
 	"cosmos-validator-mission-control/config"
 	"encoding/json"
+	"fmt"
 	"log"
 	"strconv"
 
@@ -44,8 +45,8 @@ func GetGaiaCliStatus(ops HTTPOptions, cfg *config.Config, c client.Client) {
 	var synced int
 	caughtUp := !status.Result.SyncInfo.CatchingUp
 	if !caughtUp {
-		_ = SendTelegramAlert("Your validator node is not synced!", cfg)
-		_ = SendEmailAlert("Your validator node is not synced!", cfg)
+		_ = SendTelegramAlert(fmt.Sprintf("%s Your validator node is not synced!", cfg.ValidatorName), cfg)
+		_ = SendEmailAlert(fmt.Sprintf("%s Your validator node is not synced!", cfg.ValidatorName), cfg)
 		synced = 0
 	} else {
 		synced = 1

--- a/targets/net_info.go
+++ b/targets/net_info.go
@@ -36,8 +36,8 @@ func GetNetInfo(ops HTTPOptions, cfg *config.Config, c client.Client) {
 		log.Printf("Error converting num_peers to int: %v", err)
 		numPeers = 0
 	} else if int64(numPeers) < cfg.NumPeersThreshold {
-		_ = SendTelegramAlert(fmt.Sprintf("Number of peers connected to your validator has fallen below %d", cfg.NumPeersThreshold), cfg)
-		_ = SendEmailAlert(fmt.Sprintf("Number of peers connected to your validator has fallen below %d", cfg.NumPeersThreshold), cfg)
+		_ = SendTelegramAlert(fmt.Sprintf("%s Number of peers connected to your validator has fallen below %d", cfg.ValidatorName, cfg.NumPeersThreshold), cfg)
+		_ = SendEmailAlert(fmt.Sprintf("%s Number of peers connected to your validator has fallen below %d", cfg.ValidatorName, cfg.NumPeersThreshold), cfg)
 	}
 	p1, err := createDataPoint("vcf_num_peers", map[string]string{}, map[string]interface{}{"count": numPeers})
 	if err == nil {

--- a/targets/network_block.go
+++ b/targets/network_block.go
@@ -56,8 +56,8 @@ func GetNetworkLatestBlock(ops HTTPOptions, cfg *config.Config, c client.Client)
 
 		// Send alert
 		if int64(heightDiff) >= cfg.BlockDiffThreshold {
-			_ = SendTelegramAlert(fmt.Sprintf("Block difference between network and validator has exceeded %d", cfg.BlockDiffThreshold), cfg)
-			_ = SendEmailAlert(fmt.Sprintf("Block difference between network and validator has exceeded %d", cfg.BlockDiffThreshold), cfg)
+			_ = SendTelegramAlert(fmt.Sprintf("%s Block difference between network and validator has exceeded %d", cfg.ValidatorName, cfg.BlockDiffThreshold), cfg)
+			_ = SendEmailAlert(fmt.Sprintf("%s Block difference between network and validator has exceeded %d", cfg.ValidatorName, cfg.BlockDiffThreshold), cfg)
 
 			log.Println("Sent alert of block height difference")
 		}

--- a/targets/node_addr_endpoint.go
+++ b/targets/node_addr_endpoint.go
@@ -23,8 +23,8 @@ func CheckGaiad(ops HTTPOptions, cfg *config.Config, c client.Client) {
 	}
 
 	if (resp.StatusCode != 200) && (resp.StatusCode != 202) {
-		_ = SendTelegramAlert(fmt.Sprintf("Gaiad on your validator instance is not running: RPC is DOWN : \n%v", string(resp.Body)), cfg)
-		_ = SendEmailAlert(fmt.Sprintf("Gaiad on your validator instance is not running: RPC is DOWN : \n%v", string(resp.Body)), cfg)
+		_ = SendTelegramAlert(fmt.Sprintf("%s Gaiad on your validator instance is not running: RPC is DOWN : \n%v", cfg.ValidatorName, string(resp.Body)), cfg)
+		_ = SendEmailAlert(fmt.Sprintf("%s Gaiad on your validator instance is not running: RPC is DOWN : \n%v", cfg.ValidatorName, string(resp.Body)), cfg)
 		_ = writeToInfluxDb(c, bp, "vcf_gaiad_status", map[string]string{}, map[string]interface{}{"status": 0})
 		return
 	}


### PR DESCRIPTION
when using multiple instances of chain-monit with the same TG bot & (alert-)group, needed to add validator name to all alerts.